### PR TITLE
飞机巡航更新

### DIFF
--- a/DynamicPatcher/Projects/Extension.Kratos/TechnoType/FighterAreaGuard/FighterAreaGuardData.cs
+++ b/DynamicPatcher/Projects/Extension.Kratos/TechnoType/FighterAreaGuard/FighterAreaGuardData.cs
@@ -18,6 +18,10 @@ namespace Extension.Ext
         public int GuardRange;
         public bool AutoFire;
         public int MaxAmmo;
+        public int GuardRadius;
+        public bool FindRangeAroundSelf;
+        public bool FindRangeBySelf;
+        public int ChaseRange;
 
         public FighterAreaGuardData()
         {
@@ -25,6 +29,9 @@ namespace Extension.Ext
             GuardRange = 5;
             AutoFire = false;
             MaxAmmo = 1;
+            GuardRadius = 5;
+            FindRangeAroundSelf = false;
+            ChaseRange = 30;
         }
 
         public override void Read(IConfigReader reader)
@@ -33,6 +40,9 @@ namespace Extension.Ext
             this.GuardRange = reader.Get(TITLE + "GuardRange", this.GuardRange);
             this.AutoFire = reader.Get(TITLE + "AutoFire", this.AutoFire);
             this.MaxAmmo = reader.Get(TITLE + "Ammo", this.MaxAmmo);
+            this.GuardRadius = reader.Get(TITLE + "GuardRadius", this.GuardRadius);
+            this.FindRangeAroundSelf = reader.Get(TITLE + "FindRangeAroundSelf", this.FindRangeBySelf);
+            this.ChaseRange = reader.Get(TITLE + "ChaseRange", this.ChaseRange);
         }
     }
 


### PR DESCRIPTION
Fighter.AreaGuard  ;是否启用战机区域巡航的逻辑
Fighter.GuardRange  ;巡航寻敌的范围
Fighter.AutoFire      ;是否主动攻击 
----以下为新标签-----
Fighter.GuardRadius   ;飞机巡航飞行的半径默认值5
Fighter.FindRangeAroundSelf  ;是否以战机自身位置计算寻敌半径，默认为false，即以ctrl+alt点击的位置为中心点寻敌，如果为是择以战机当前所在位置寻敌
Fighter.ChaseRange ;战机最大追击距离，默认为30,-1为无限